### PR TITLE
PR: métodos de replicação de mensagens

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ kafka-reassign-partitions.sh --zookeeper <YOUR_ZOOKEEPER> --verify --reassignmen
 
 Com isso será criado o Broker Kafka, Zookeper, Schema Registry e o Kafka UI da Confluent, onde o gerenciamento será realizado pela interface e pode ser acessado acessando a url [Control Center](http://localhost:9021/).
 
+
+## Mirror Maker 2
+
+É possivel usar o Mirror Maker para replicar a mensagem de tópicos Kafka entre clusters diferentes, para isso será necessário executar o  seguinte comando abaixo:
+
+``` sh
+./kafka-mirror-maker.sh --consumer.config ../../cluster-source.properties --producer.config ../../cluster-target.properties --whitelist "<nome-do-tópico"
+```
+
+
+
 ## Referencias
 
 - [Docker](https://www.docker.com/)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ Com isso será criado o Broker Kafka, Zookeper, Schema Registry e o Kafka UI da 
 ```
 
 
+## Kafka Confluent Replicator
+Também é possivel utilizar o Kafka Confluent Replicator para replicar a mensagem de tópicos Kafka entre clusters diferentes, para isso será necessário executar o  seguinte comando abaixo:
+
+``` sh
+curl --location 'http://localhost:8083/connectors' \
+--header 'Content-Type: application/json' \
+--data '{
+  "name": "replicator-teste",
+  "config": {
+    "connector.class": "io.confluent.connect.replicator.ReplicatorSourceConnector",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "src.kafka.bootstrap.servers": "kafka2:9092",
+    "dest.kafka.bootstrap.servers": "kafka3:9092",
+    "topic.whitelist": "<nome-do-topico>",
+    "confluent.topic.replication.factor": 1,
+    "provenance.header.enable": true
+  }
+}
+'
+```
+
+Com isso será criado o conector no servidor do kafka connect que está no Docker.
 
 ## Referencias
 

--- a/docker/confluent-replicator-test/docker-compose.yaml
+++ b/docker/confluent-replicator-test/docker-compose.yaml
@@ -1,0 +1,60 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    environment:
+      JVMFLAGS: "-Djava.security.auth.login.config=/etc/zookeeper/zookeeper_jaas.conf"
+    volumes:
+      - ./zookeeper_jaas.conf:/etc/zookeeper/zookeeper_jaas.conf
+    ports:
+     - 2181:2181
+     
+  kafka:
+    image: wurstmeister/kafka:2.13-2.8.1
+    depends_on:
+      - zookeeper
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: INTERNAL://:9093,EXTERNAL://:9092
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9093,EXTERNAL://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:SASL_PLAINTEXT,EXTERNAL:SASL_PLAINTEXT
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_jaas.conf"
+    volumes:
+      - ./kafka_server_jaas.conf:/etc/kafka/kafka_jaas.conf
+
+
+  kafka2:
+    image: wurstmeister/kafka:2.13-2.8.1
+    depends_on:
+      - zookeeper2
+    ports:
+      - 9094:9094
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper2:2181
+      KAFKA_LISTENERS: INTERNAL://:9095,EXTERNAL://:9094
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:9095,EXTERNAL://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:SASL_PLAINTEXT,EXTERNAL:SASL_PLAINTEXT
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_jaas.conf"
+    volumes:
+      - ./kafka_server_jaas.conf:/etc/kafka/kafka_jaas.conf
+
+  zookeeper2:
+    image: wurstmeister/zookeeper:3.4.6
+    environment:
+      JVMFLAGS: "-Djava.security.auth.login.config=/etc/zookeeper/zookeeper_jaas.conf"
+    volumes:
+      - ./zookeeper_jaas.conf:/etc/zookeeper/zookeeper_jaas.conf
+    ports:
+     - 2182:2181

--- a/docker/confluent-replicator-test/kafka_server_jaas.conf
+++ b/docker/confluent-replicator-test/kafka_server_jaas.conf
@@ -1,0 +1,12 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret";
+};
+
+Client {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret";
+};

--- a/docker/confluent-replicator-test/mirro-maker-2/Dockerfile
+++ b/docker/confluent-replicator-test/mirro-maker-2/Dockerfile
@@ -1,0 +1,4 @@
+FROM confluentinc/cp-kafka-connect:7.2.1
+
+# Instalar o Confluent Replicator
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-replicator:latest

--- a/docker/confluent-replicator-test/mirro-maker-2/cluster-source.properties
+++ b/docker/confluent-replicator-test/mirro-maker-2/cluster-source.properties
@@ -1,0 +1,10 @@
+bootstrap.servers=localhost:8098
+group.id=mirrormaker-group
+enable.auto.commit=false
+isolation.level=read_committed
+
+# Configurações específicas do consumer, como autenticação
+
+# security.protocol=SASL_PLAINTEXT
+# sasl.mechanism=PLAIN
+# sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";

--- a/docker/confluent-replicator-test/mirro-maker-2/cluster-target.properties
+++ b/docker/confluent-replicator-test/mirro-maker-2/cluster-target.properties
@@ -1,0 +1,11 @@
+bootstrap.servers=localhost:8099
+
+enable.idempotence=true
+transactional.id=3
+
+# Configurações específicas do producer, como autenticação
+
+# security.protocol=SASL_PLAINTEXT
+# sasl.mechanism=PLAIN
+# sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
+

--- a/docker/confluent-replicator-test/mirro-maker-2/docker-compose.yaml
+++ b/docker/confluent-replicator-test/mirro-maker-2/docker-compose.yaml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.2.1
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+  kafka1:
+    image: confluentinc/cp-kafka:7.2.1
+    container_name: kafka1
+    ports:
+      - "8097:8097"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:8097,INTERNAL://kafka1:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+  kafka2:
+    image: confluentinc/cp-kafka:7.2.1
+    container_name: kafka2
+    ports:
+      - "8098:8098"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:8098,INTERNAL://kafka2:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+  kafka3:
+    image: confluentinc/cp-kafka:7.2.1
+    container_name: kafka3
+    ports:
+      - "8099:8099"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:8099,INTERNAL://kafka3:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL

--- a/docker/confluent-replicator-test/mirro-maker-2/docker-compose.yaml
+++ b/docker/confluent-replicator-test/mirro-maker-2/docker-compose.yaml
@@ -44,3 +44,28 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: EXTERNAL://localhost:8099,INTERNAL://kafka3:9092
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+  
+  kafka-connect:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: kafka-connect
+    depends_on:
+      - kafka1
+      - kafka2
+      - kafka3
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: "kafka1:9092,kafka2:9092,kafka3:9092"
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: "kafka-connect-group"
+      CONNECT_CONFIG_STORAGE_TOPIC: "connect-configs"
+      CONNECT_OFFSET_STORAGE_TOPIC: "connect-offsets"
+      CONNECT_STATUS_STORAGE_TOPIC: "connect-status"
+      CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
+      CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
+      CONNECT_INTERNAL_KEY_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_INTERNAL_VALUE_CONVERTER: "org.apache.kafka.connect.json.JsonConverter"
+      CONNECT_REST_ADVERTISED_HOST_NAME: "kafka-connect"
+      CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"

--- a/docker/confluent-replicator-test/zookeeper_jaas.conf
+++ b/docker/confluent-replicator-test/zookeeper_jaas.conf
@@ -1,0 +1,4 @@
+Server {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    user_admin="admin-secret";
+};


### PR DESCRIPTION
Adicionando exemplos de implementações de ferramentas para replicar mensagens no Kafka utilizando as seguintes ferramentas:

- Conector Kafka Confluent REplicator
- Mirror Maker 2

Os exemplos foram realizados com clusters Kafka no Docker sem utilizar autenticação